### PR TITLE
Refactor deadnix-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,15 @@ inputs:
   flags:
     description: 'Command-line flags to deadnix'
     required: false
-    default: '--no-lambda-pattern-names'
+    default: '--edit'
+  directory:
+    description: 'Command-line flags to deadnix'
+    required: false
+    default: '.'
+  create_pr:
+    description: 'Whether to create a PR'
+    required: false
+    default: 'true'
   commit_message:
     description: 'Commit message'
     required: false
@@ -13,34 +21,17 @@ runs:
   using: "composite"
   steps:
     - name: Nix dead code analysis
-      run: |
-        TMP=$(mktemp -d)
-        nix build -o $TMP/deadnix github:astro/deadnix
-        MSG="$($TMP/deadnix/bin/deadnix ${{ inputs.flags }} -e .)"
-        MSG="${MSG//'%'/'%25'}"
-        MSG="${MSG//$'\n'/'%0A'}"
-        MSG="${MSG//$'\r'/'%0D'}"
-        echo -n "::set-output name=msg::$MSG"
+      run: 'nix run nixpkgs#deadnix -- ${{ inputs.flags }} ${{ inputs.directory }}'
       shell: bash
       id: deadnix
-    - run: |
-        if ! git diff --quiet --exit-code ; then
-          git commit -a -F - <<EOF
-          ${{ inputs.commit_message }}
-        EOF
-        fi
-      env:
-        GIT_AUTHOR_NAME: github-actions[bot]
-        GIT_AUTHOR_EMAIL: <github-actions[bot]@users.noreply.github.com>
-        GIT_COMMITTER_NAME: github-actions[bot]
-        GIT_COMMITTER_EMAIL: <github-actions[bot]@users.noreply.github.com>
-      shell: bash
     - name: Create PR
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
+      if: inputs.create_pr == 'true'
       with:
         branch: deadnix
         delete-branch: true
         title: "${{ inputs.commit_message }}"
+        commit-message: "${{ inputs.commit_message }}"
         body: |
           Automated changes by the [deadnix-action](https://github.com/astro/deadnix-action) GitHub Action.
 branding:


### PR DESCRIPTION
Hi,

I made this fork that I use personally and I was wondering if you'd be interested in upstreaming my changes:

- Add a dependabot to make sure github actions are always up to date
- Allow user to specify a directory on which to run deadnix
- Make PR creation optional
- Only have '--edit' as default flag
- Allow user to only check for dead code instead of automatically fixing it
- Remove old commit and pr code  and streamline it.
