### PR TITLE
README: Updated dependencies in action usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ jobs:
       runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v2
-          - uses: cachix/install-nix-action@v16
-          - uses: cachix/cachix-action@v10
+          - uses: cachix/install-nix-action@v22
+          - uses: cachix/cachix-action@v12
             with:
               name: deadnix
           - uses: astro/deadnix-action@main


### PR DESCRIPTION
Using usage example as it is does not work until I updated the action dependencies, this MR only updates the dependencies to the latest version and it works as you can see [here](https://github.com/luisnquin/nixos-config/actions/runs/5863719136/job/15897672919)

![image](https://github.com/astro/deadnix-action/assets/86449787/8c3758ff-59dc-4bf9-8bd9-50e2ad040254)
