### PR TITLE
Set base ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ runs:
       with:
         author: '${{ inputs.author }}'
         branch: deadnix
+        base: ${{ github.head_ref }}
         delete-branch: true
         title: '${{ inputs.commit_message }}'
         commit-message: '${{ inputs.commit_message }}'


### PR DESCRIPTION
When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.

ref: https://github.com/peter-evans/autopep8/issues/59

I had this issue with my branch workflow 
https://github.com/Azd325/dotfiles/actions/runs/6282259747/workflow
when used the base branch it passed.
https://github.com/Azd325/dotfiles/actions/runs/6282304320?pr=7
