### PR TITLE
Fix yaml syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ name: Dead code analysis
 jobs:
   deadnix:
     name: Deadnix
-      runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v2
-          - uses: cachix/install-nix-action@v22
-          - uses: cachix/cachix-action@v12
-            with:
-              name: deadnix
-          - uses: astro/deadnix-action@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - uses: cachix/cachix-action@v14
+        with:
+          name: deadnix
+      - uses: astro/deadnix-action@main
 ```
 
 `git add`, `git commit`, `git push`, be happy.


### PR DESCRIPTION
Looks like the `steps` block is indented too much.

Error from prettier formatter:

```
[error] /home/will/code/system/.github/workflows/deadnix.yaml: SyntaxError: All collection items must start at the same column (7:5)
[error]    5 | jobs:
[error]    6 |   deadnix:
[error] >  7 |     name: Deadnix
[error]      |     ^^^^^^^^^^^^^
[error] >  8 |       runs-on: ubuntu-latest
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] >  9 |         steps:
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 10 |           - uses: actions/checkout@v2
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 11 |           - uses: cachix/install-nix-action@v22
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 12 |           - uses: cachix/cachix-action@v12
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 13 |             with:
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 14 |               name: deadnix
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 15 |           - uses: astro/deadnix-action@main
[error]      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] > 16 |
[error]      | ^
```